### PR TITLE
Remove excessive end game check calls

### DIFF
--- a/BaghChal.sln
+++ b/BaghChal.sln
@@ -17,30 +17,51 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{7AE1621D-9DC3-4306-BE9B-651265178773}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7AE1621D-9DC3-4306-BE9B-651265178773}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7AE1621D-9DC3-4306-BE9B-651265178773}.Debug|x64.ActiveCfg = Debug|x64
+		{7AE1621D-9DC3-4306-BE9B-651265178773}.Debug|x64.Build.0 = Debug|x64
 		{7AE1621D-9DC3-4306-BE9B-651265178773}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7AE1621D-9DC3-4306-BE9B-651265178773}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7AE1621D-9DC3-4306-BE9B-651265178773}.Release|x64.ActiveCfg = Release|x64
+		{7AE1621D-9DC3-4306-BE9B-651265178773}.Release|x64.Build.0 = Release|x64
 		{827C67B0-90C5-4C21-B57A-95B1F7935A45}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{827C67B0-90C5-4C21-B57A-95B1F7935A45}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{827C67B0-90C5-4C21-B57A-95B1F7935A45}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{827C67B0-90C5-4C21-B57A-95B1F7935A45}.Debug|x64.Build.0 = Debug|Any CPU
 		{827C67B0-90C5-4C21-B57A-95B1F7935A45}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{827C67B0-90C5-4C21-B57A-95B1F7935A45}.Release|Any CPU.Build.0 = Release|Any CPU
+		{827C67B0-90C5-4C21-B57A-95B1F7935A45}.Release|x64.ActiveCfg = Release|Any CPU
+		{827C67B0-90C5-4C21-B57A-95B1F7935A45}.Release|x64.Build.0 = Release|Any CPU
 		{73A2EDD5-D318-439F-9508-32F7E2F6C96F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{73A2EDD5-D318-439F-9508-32F7E2F6C96F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{73A2EDD5-D318-439F-9508-32F7E2F6C96F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{73A2EDD5-D318-439F-9508-32F7E2F6C96F}.Debug|x64.Build.0 = Debug|Any CPU
 		{73A2EDD5-D318-439F-9508-32F7E2F6C96F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{73A2EDD5-D318-439F-9508-32F7E2F6C96F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{73A2EDD5-D318-439F-9508-32F7E2F6C96F}.Release|x64.ActiveCfg = Release|x64
+		{73A2EDD5-D318-439F-9508-32F7E2F6C96F}.Release|x64.Build.0 = Release|x64
 		{F0EFE750-82B3-4AD1-882B-66D288C6FD73}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F0EFE750-82B3-4AD1-882B-66D288C6FD73}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F0EFE750-82B3-4AD1-882B-66D288C6FD73}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F0EFE750-82B3-4AD1-882B-66D288C6FD73}.Debug|x64.Build.0 = Debug|Any CPU
 		{F0EFE750-82B3-4AD1-882B-66D288C6FD73}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F0EFE750-82B3-4AD1-882B-66D288C6FD73}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F0EFE750-82B3-4AD1-882B-66D288C6FD73}.Release|x64.ActiveCfg = Release|x64
+		{F0EFE750-82B3-4AD1-882B-66D288C6FD73}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E013102B-DC1E-49D2-A549-CE9A0F762C1F}
+	EndGlobalSection
+	GlobalSection(Performance) = preSolution
+		HasPerformanceSessions = true
 	EndGlobalSection
 EndGlobal

--- a/BaghChal.sln
+++ b/BaghChal.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.15
+VisualStudioVersion = 15.0.27130.2036
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BaghChal", "BaghChal\BaghChal.csproj", "{7AE1621D-9DC3-4306-BE9B-651265178773}"
 EndProject
@@ -12,6 +12,9 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BaghChalAI", "BaghChalAI\BaghChalAI.csproj", "{F0EFE750-82B3-4AD1-882B-66D288C6FD73}"
 EndProject
 Global
+	GlobalSection(Performance) = preSolution
+		HasPerformanceSessions = true
+	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU

--- a/BaghChal/BaghChal.cs
+++ b/BaghChal/BaghChal.cs
@@ -296,27 +296,38 @@ namespace BaghChal
                 start + 12, start + 14, start + 16,
             };
         }
-
+        
         public MoveResult Move(Pieces piece, (int x, int y) start, (int x, int y) end)
         {
             var move = TryMove(piece, start, end);
+            return MoveDanger(piece, start, end, move);
+
+        }
+
+        /// <summary>
+        /// This move function skips the TryMove check. Used to speed up the AI. Use with care.
+        /// </summary>
+        public MoveResult MoveDanger(Pieces piece, (int x, int y) start, (int x, int y) end, MoveResult move)
+        {
             var endIndex = TranslateToBoardIndex(end);
             var startIndex = TranslateToBoardIndex(start);
-            switch(move)
+            switch (move)
             {
                 case MoveResult.GoatPlaced:
                     PerformGameMove(piece, -1, endIndex);
-                    return (CheckGameEnd(piece)) ? MoveResult.GoatWin : move;
+                    return //(CheckGameEnd(piece)) ? MoveResult.GoatWin : 
+                    move;
                 case MoveResult.GoatCaptured:
                     IsJumpValid(piece, startIndex, endIndex, out int captureIndex);
                     PerformGameMove(piece, startIndex, endIndex, captureIndex);
-                    return (CheckGameEnd(piece)) ? MoveResult.TigerWin : move;
+                    return //(CheckGameEnd(piece)) ? MoveResult.TigerWin : 
+                    move;
                 case MoveResult.MoveOK:
                     PerformGameMove(piece, startIndex, endIndex);
-                    return (CheckGameEnd(piece)) ? MoveResult.GoatWin : move;
+                    return //(CheckGameEnd(piece)) ? MoveResult.GoatWin : 
+                    move;
             }
             return move;
-            
         }
 
         public MoveResult TryMove(Pieces piece, (int x, int y) start, (int x, int y) end)

--- a/BaghChal/BaghChal.cs
+++ b/BaghChal/BaghChal.cs
@@ -59,7 +59,7 @@ namespace BaghChal
 
         public override int GetHashCode()
         {
-            // TODO: Not sure if this is a good hash function.
+            // TODO: Not sure if this is a good hash function. Issue added to make it handle transposed positions.
             return Board[0].GetHashCode() ^ Board[1].GetHashCode();
         }
 
@@ -101,7 +101,7 @@ namespace BaghChal
 
             foreach (var (pieceType, position) in args)
             {
-                var index = GameMove.TranslateToBoardIndex(position);
+                var index = GameBoard.TranslateToBoardIndex(position);
                 PlacePeiceAtIndex(pieceType, index);
             }
         }
@@ -198,12 +198,12 @@ namespace BaghChal
 
         public Dictionary<(int x, int y), List<(MoveResult result, (int x, int y) positions)>> GetTigerMoves()
         {
-            Dictionary<(int x, int y), List<(MoveResult result, (int x, int y) positions)>> res = new Dictionary<(int x, int y), List<(MoveResult result, (int x, int y) posistion)>>(4);
+            var res = new Dictionary<(int x, int y), List<(MoveResult result, (int x, int y) posistion)>>(4);
             for (int i = 8; i < 41; i++)
             {
                 if ((Board[(int)Pieces.Tiger] & (1L << i)) > 0)
                 {
-                    List<(MoveResult result, (int x, int y) posistion)> returnValue = new List<(MoveResult result, (int x, int y) posistion)>();
+                    var returnValue = new List<(MoveResult result, (int x, int y) posistion)>(16);
                     var tigerPosition = TranslatetFromBoardIndex(i);
                     var linkedPositions = GetLinkedPositions(i);
                     for (int target = 0; target < linkedPositions.Length; target++)
@@ -212,11 +212,12 @@ namespace BaghChal
                         var moveResult = TryMove(Pieces.Tiger, tigerPosition, targetPosition);
                         returnValue.Add((moveResult, targetPosition));
                     }
-                    // TODO: Now have to check if there are any jump points. Wonder if a filter on goats is faster than just checking all jumps?
+                    // TODO: Now checks if there are any jump points. Might be faster to filter on adjacent goats first?
                     linkedPositions = GetJumpLinkedPositions(i);
                     for (int target = 0; target < linkedPositions.Length; target++)
                     {
                         var endIndex = linkedPositions[target];
+                        // TODO: This check is not complete. Create a index OutOfBounds check function and use it instead.
                         if (endIndex < 0 || endIndex > 48) continue; // Code to skip out of bounds for jumps.
                         var targetPosition = TranslatetFromBoardIndex(endIndex);
                         var moveResult = TryMove(Pieces.Tiger, tigerPosition, targetPosition);
@@ -269,16 +270,8 @@ namespace BaghChal
             return res;
         }
 
-
-        public bool GetAllMoves(Pieces piece, (int, int) position)
-        {
-            // TODO: Implement.
-            return false;
-        }
-
         private int[] GetLinkedPositions(int start)
         {
-            // TODO: Include jump links here all at ones?
             return new int[] {
                 start - 8, start - 7, start - 6,
                 start - 1,            start + 1,
@@ -336,16 +329,16 @@ namespace BaghChal
             if (piece != CurrentUsersTurn)
                 return MoveResult.NotPlayersTurn;
             // If 0,0 is used as start position during goat placement, then check this early before errors on start position is found.
+            if (IsOutOfBounds(end))
+                return MoveResult.OutOfBounds;
             var endIndex = TranslateToBoardIndex(end);
             if (piece == Pieces.Goat && start.Equals((0, 0)))
             {
-                if (IsOutOfBounds(end))
-                    return MoveResult.OutOfBounds;
                 if (IsPieceAtIndex(Pieces.Any, endIndex))
                     return MoveResult.TargetLocationOccupied;
                 return MoveResult.GoatPlaced;
             }
-            if (IsOutOfBounds(start) || IsOutOfBounds(end))
+            if (IsOutOfBounds(start))
                 return MoveResult.OutOfBounds;
             var startIndex = TranslateToBoardIndex(start);
             if (piece != GetPieceAtIndex(startIndex))
@@ -431,7 +424,6 @@ namespace BaghChal
 
         private void PerformGameMove(Pieces piece, int startIndex, int endIndex, int captureIndex = -1)
         {
-            // TODO: Fix this code! 3 moves: Place, move, and capture. Capture also use move.
             if (captureIndex != -1)
             {
                 var helper = this.Board;
@@ -472,14 +464,14 @@ namespace BaghChal
             Tick();
             return;
         }
-        
+
         /// <summary>
         /// Translate a 1 indexed x, y coordinate into a index position on the 
         /// internal board storage.
         /// </summary>
-        private static int TranslateToBoardIndex((int x, int y) position)
+        public static int TranslateToBoardIndex((int x, int y) position)
         {
-            // TODO: Should perhaps check fo overflow, in case the IsOutOfBounds check uses index instead of position.
+            // TODO: Should rewrite the entire internal code to only work with indexes. Tried a dictionary and it was slower!
             return position.x + (position.y * 7);
         }
 
@@ -496,7 +488,6 @@ namespace BaghChal
 
         private bool IsOutOfBounds((int x, int y) position)
         {
-            // TODO: Is it better to check using index instead?
             return position.x < 1 || position.y < 1 ||
                 position.x > 5 || position.y > 5;
         }
@@ -528,66 +519,4 @@ namespace BaghChal
         OutOfReach = 3,
     }
 
-    public enum InvalidGameMove : int
-    {
-        OutOfBounds = 1,
-        TryToMoveIncorrectPiece = 2,
-        TargetLocationOccupied = 3,
-    }
-
-    public class GameMoveException : Exception
-    {
-        public InvalidGameMove TypeOfViolation { get; set; }
-
-        public GameMoveException(string message, InvalidGameMove type) : base(message)
-        {
-            TypeOfViolation = type;
-        }
-    }
-
-    public class GameMove
-    {
-
-        public bool TryMove(Pieces piece, (int x, int y) startPosition, (int x, int y) endPosition, GameBoard board)
-        {
-            if(IsOutOfBounds(startPosition) || IsOutOfBounds(endPosition))
-            {
-                throw new GameMoveException("Start or end position is out of bounds.", InvalidGameMove.OutOfBounds);
-            }
-            else if (IsPieceAtLocation(piece, startPosition, board))
-            {
-                throw new GameMoveException("Selected piece is not at start position.", InvalidGameMove.TryToMoveIncorrectPiece);
-            }
-            else if (IslocationEmpty(endPosition, board))
-            {
-                throw new GameMoveException("Target location is not empty.", InvalidGameMove.TargetLocationOccupied);
-            }
-            else
-                return false;
-        }
-
-        private bool IsPieceAtLocation(Pieces piece, (int x, int y) position, GameBoard board)
-        {
-            return board.IsPieceAtIndex(piece, TranslateToBoardIndex(position));
-        }
-
-        private bool IslocationEmpty((int x, int y) position, GameBoard board)
-        {
-            return !IsPieceAtLocation(Pieces.Any, position, board);
-        }
-
-        public bool IsOutOfBounds((int x, int y) position)
-        {
-            return position.x < 0 || position.y < 0; // TODO: Implement logic.
-        }
-
-        /// <summary>
-        /// Translate a <see cref="BoardPosition"/> into a index position on 
-        /// the internal board storage.
-        /// </summary>
-        public static int TranslateToBoardIndex((int x, int y) position)
-        {
-            return position.x + (position.y * 7);
-        }
-    }
 }

--- a/BaghChal/BaghChal.csproj
+++ b/BaghChal/BaghChal.csproj
@@ -20,6 +20,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -28,6 +29,24 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/BaghChalAI/BaghChalAI.cs
+++ b/BaghChalAI/BaghChalAI.cs
@@ -217,7 +217,7 @@ namespace BaghChalAI
                     foreach (var move in piece.Value.Where(x => GoodMoves.Contains(x.result)))
                     {
                         var board = (GameBoard)(tempBoard).Clone();
-                        var moveResult = board.Move(Pieces.Tiger, piece.Key, move.positions);
+                        var moveResult = board.MoveDanger(Pieces.Tiger, piece.Key, move.positions, move.result);
                         result.Add(new NodeBaseClass(board, Pieces.Goat, new GameMove(Pieces.Tiger, piece.Key, move.positions)));
                     }
                 }
@@ -240,9 +240,8 @@ namespace BaghChalAI
                         foreach (var move in piece.Value.Where(x => GoodMoves.Contains(x.result)))
                         {
                             var board = (GameBoard)(tempBoard).Clone();
-                            var moveResult = board.Move(Pieces.Goat, piece.Key, move.positions);
-                            if(GoodMoves.Contains(moveResult))
-                                result.Add(new NodeBaseClass(board, Pieces.Tiger, new GameMove(Pieces.Goat, piece.Key, move.positions)));
+                            var moveResult = board.MoveDanger(Pieces.Goat, piece.Key, move.positions, move.result);
+                            result.Add(new NodeBaseClass(board, Pieces.Tiger, new GameMove(Pieces.Goat, piece.Key, move.positions)));
                         }
                     }
                 }
@@ -274,7 +273,7 @@ namespace BaghChalAI
 
         public override string ToString()
         {
-            return $"S: {Score}, C: {Checks}, H: {HashHits}, P: {Piece}, S: {Start}, E: {End}.";
+            return $"S: {Score}, C: {Checks}, H: {HashHits}, P: {Piece}, S: {Start}, E: {End}";
         }
     }
 }

--- a/BaghChalAI/BaghChalAI.cs
+++ b/BaghChalAI/BaghChalAI.cs
@@ -175,7 +175,7 @@ namespace BaghChalAI
         public GameBoard GameBoard { get; set; }
         public Pieces Player { get; set; }
         public GameMove Step { get; set; }
-        public static readonly MoveResult[] GoodMoves = { MoveResult.MoveOK, MoveResult.TigerWin, MoveResult.GoatCaptured, MoveResult.GoatPlaced, MoveResult.GoatWin, MoveResult.Draw};
+        public static readonly MoveResult[] GoodMoves = { MoveResult.MoveOK, MoveResult.TigerWin, MoveResult.GoatCaptured, MoveResult.GoatPlaced, MoveResult.GoatWin, MoveResult.Draw };
 
         public NodeBaseClass(GameBoard gameBoard, Pieces player, GameMove step)
         {
@@ -195,17 +195,16 @@ namespace BaghChalAI
             {
                 if (GameBoard.CheckGameEnd(Pieces.Goat)) { return int.MaxValue; }
             }
-                
+
 
             // Count score for Tiger, then revert for goat.
             int sum = GameBoard.GoatsCaptured * 1000;
             // Adding play to return to try and play longer.
             return (Player == Pieces.Tiger) ? sum : -sum + GameBoard.Ply;
         }
-
+        
         public List<NodeBaseClass> GetChildNodes()
         {
-            var goodMove = new List<MoveResult>() { MoveResult.MoveOK, MoveResult.TigerWin, MoveResult.GoatCaptured, MoveResult.GoatWin, MoveResult.Draw };
             var tempBoard = (GameBoard)GameBoard.Clone();
             var result = new List<NodeBaseClass>();
             // Start just playing the tiger and goat placements.

--- a/BaghChalAI/BaghChalAI.csproj
+++ b/BaghChalAI/BaghChalAI.csproj
@@ -20,6 +20,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -28,6 +29,24 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/BaghChalConsoleApplication/BaghChalConsoleApplication.csproj
+++ b/BaghChalConsoleApplication/BaghChalConsoleApplication.csproj
@@ -31,6 +31,26 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/BaghChalConsoleApplication/Program.cs
+++ b/BaghChalConsoleApplication/Program.cs
@@ -13,45 +13,54 @@ namespace BaghChalConsoleApplication
         {
             var board = new GameBoard();
             var sw = new System.Diagnostics.Stopwatch();
-            while(true)
+            int numberOfTestTurns = 20;
+            while(numberOfTestTurns-- > 0)
             {
-                
-                Console.WriteLine("Type start coordinate then enter (x,y).");
-                var inputStart = Console.ReadLine().Split(',');
-                Console.WriteLine("Type end coordinate then enter (x,y).");
-                var inputEnd = Console.ReadLine().Split(',');
-                if (int.TryParse(inputStart[0], out int xs) && int.TryParse(inputStart[1], out int ys) &&
-                    int.TryParse(inputEnd[0], out int xe) && int.TryParse(inputEnd[1], out int ye)) {
-                    var humanRes = board.Move(board.CurrentUsersTurn, (xs, ys), (xe, ye));
-                    Console.WriteLine(humanRes);
-                }
-                Console.WriteLine(board.ToString());
-
-                sw.Restart();
-                var move = BaghChalAI.MinMax.GetMove(board);
-                sw.Stop();
-                var aiRes = board.Move(move.Piece, move.Start, move.End);
-                Console.WriteLine($"MoveResult: {aiRes}, Time (ms): {sw.ElapsedMilliseconds}, " + move.ToString());
-                Console.WriteLine(board.ToString());
+                //HumanMove(board);
+                AIMove(board, sw);
+                AIMove(board, sw);
             }
 
             //board.PlacePeiceAtIndex(Pieces.Tiger, 8);
             //board.PlacePeiceAtIndex(Pieces.Tiger, 12);
             //board.PlacePeiceAtIndex(Pieces.Tiger, 36);
             //board.PlacePeiceAtIndex(Pieces.Tiger, 40);
-            board = new GameBoard(7, 16, 0, Pieces.Tiger,
-                (Pieces.Tiger, (1, 1)), (Pieces.Tiger, (2, 2)), (Pieces.Tiger, (1, 4)), (Pieces.Tiger, (2, 4)),
-                (Pieces.Goat, (1, 2)), (Pieces.Goat, (1, 3)), (Pieces.Goat, (2, 3)), (Pieces.Goat, (3, 3))
-                );
+            //board = new GameBoard(7, 16, 0, Pieces.Tiger,
+            //    (Pieces.Tiger, (1, 1)), (Pieces.Tiger, (2, 2)), (Pieces.Tiger, (1, 4)), (Pieces.Tiger, (2, 4)),
+            //    (Pieces.Goat, (1, 2)), (Pieces.Goat, (1, 3)), (Pieces.Goat, (2, 3)), (Pieces.Goat, (3, 3))
+            //    );
 
-            
+            //int i = 0;
+            //PrintGameBoard(board, ++i);
 
-            int i = 0;
-            PrintGameBoard(board, ++i);
+            //board.PlacePeiceAtIndex(Pieces.Goat, 10);
+            //var res = board.GetTigerMoves();
+            //PrintGameBoard(board, ++i);
+        }
 
-            board.PlacePeiceAtIndex(Pieces.Goat, 10);
-            var res = board.GetTigerMoves();
-            PrintGameBoard(board, ++i);
+        private static void HumanMove(GameBoard board)
+        {
+            Console.WriteLine("Type start coordinate then enter (x,y).");
+            var inputStart = Console.ReadLine().Split(',');
+            Console.WriteLine("Type end coordinate then enter (x,y).");
+            var inputEnd = Console.ReadLine().Split(',');
+            if (int.TryParse(inputStart[0], out int xs) && int.TryParse(inputStart[1], out int ys) &&
+                int.TryParse(inputEnd[0], out int xe) && int.TryParse(inputEnd[1], out int ye))
+            {
+                var humanRes = board.Move(board.CurrentUsersTurn, (xs, ys), (xe, ye));
+                Console.WriteLine(humanRes);
+            }
+            Console.WriteLine(board.ToString());
+        }
+
+        private static void AIMove(GameBoard board, System.Diagnostics.Stopwatch sw)
+        {
+            sw.Restart();
+            var move = BaghChalAI.MinMax.GetMove(board);
+            sw.Stop();
+            var aiRes = board.Move(move.Piece, move.Start, move.End);
+            Console.WriteLine($"MoveResult: {aiRes}, Time (ms): {sw.ElapsedMilliseconds}, Checks/ms: {move.Checks/(sw.ElapsedMilliseconds+1)}, {move.ToString()}.");
+            Console.WriteLine(board.ToString());
         }
 
         static void PrintGameBoard(GameBoard board, int round)

--- a/BaghChalConsoleApplication/Program.cs
+++ b/BaghChalConsoleApplication/Program.cs
@@ -13,6 +13,8 @@ namespace BaghChalConsoleApplication
         {
             var board = new GameBoard();
             var sw = new System.Diagnostics.Stopwatch();
+            var sw2 = new System.Diagnostics.Stopwatch();
+            sw2.Start();
             int numberOfTestTurns = 20;
             while(numberOfTestTurns-- > 0)
             {
@@ -20,7 +22,9 @@ namespace BaghChalConsoleApplication
                 AIMove(board, sw);
                 AIMove(board, sw);
             }
-
+            sw2.Stop();
+            Console.WriteLine(sw2.ElapsedMilliseconds);
+            Console.ReadKey();
             //board.PlacePeiceAtIndex(Pieces.Tiger, 8);
             //board.PlacePeiceAtIndex(Pieces.Tiger, 12);
             //board.PlacePeiceAtIndex(Pieces.Tiger, 36);

--- a/BaghChalTests/GameBoardTests.cs
+++ b/BaghChalTests/GameBoardTests.cs
@@ -165,8 +165,9 @@ namespace BaghChal.Tests
             result = board.Move(Pieces.Goat, (1, 3), (2, 3));
             Assert.AreEqual(MoveResult.MoveOK, result, "Goat unable to move one space.");
             result = board.Move(Pieces.Tiger, (2, 4), (2, 2));
-            Assert.AreEqual(MoveResult.TigerWin, result, "Tiger unable to win.");
-
+            Assert.AreEqual(MoveResult.GoatCaptured, result, "Tiger unable to make winning move.");
+            var GameEnd = board.CheckGameEnd(Pieces.Tiger);
+            Assert.AreEqual(true, GameEnd, "Tiger unable to win.");
             // Set board up for goat win.
             //TTGG- 
             //TTG-G
@@ -181,7 +182,9 @@ namespace BaghChal.Tests
                 (Pieces.Goat, (3, 3)), (Pieces.Goat, (4, 4))
                 );
             result = board.Move(Pieces.Goat, (5, 2), (4, 2));
-            Assert.AreEqual(MoveResult.GoatWin, result, "Goat unable to win.");
+            Assert.AreEqual(MoveResult.MoveOK, result, "Goat unable to make winning move.");
+            GameEnd = board.CheckGameEnd(Pieces.Goat);
+            Assert.AreEqual(true, GameEnd, "Goat unable to win.");
 
             // Test if Tiger finds jump to escape.
             board = new GameBoard(46, 0, 4, Pieces.Goat,

--- a/BaghChalTests/GameMoveTests.cs
+++ b/BaghChalTests/GameMoveTests.cs
@@ -14,13 +14,13 @@ namespace BaghChal.Tests
         [TestMethod()]
         public void TranslateToBoardIndexTest()
         {
-            Assert.AreEqual<int>(8, GameMove.TranslateToBoardIndex((1, 1)));
-            Assert.AreEqual<int>(12, GameMove.TranslateToBoardIndex((5, 1)));
-            Assert.AreEqual<int>(36, GameMove.TranslateToBoardIndex((1, 5)));
-            Assert.AreEqual<int>(40, GameMove.TranslateToBoardIndex((5, 5)));
-            Assert.AreEqual<int>(24, GameMove.TranslateToBoardIndex((3, 3)));
-            Assert.AreEqual<int>(0, GameMove.TranslateToBoardIndex((0, 0)));
-            Assert.AreEqual<int>(-8, GameMove.TranslateToBoardIndex((-1, -1)));
+            Assert.AreEqual<int>(8,  GameBoard.TranslateToBoardIndex((1, 1)));
+            Assert.AreEqual<int>(12, GameBoard.TranslateToBoardIndex((5, 1)));
+            Assert.AreEqual<int>(36, GameBoard.TranslateToBoardIndex((1, 5)));
+            Assert.AreEqual<int>(40, GameBoard.TranslateToBoardIndex((5, 5)));
+            Assert.AreEqual<int>(24, GameBoard.TranslateToBoardIndex((3, 3)));
+            Assert.AreEqual<int>(0,  GameBoard.TranslateToBoardIndex((0, 0)));
+            Assert.AreEqual<int>(-8, GameBoard.TranslateToBoardIndex((-1, -1)));
         }
     }
 }


### PR DESCRIPTION
Resolves #4.
Removed the excessive end game call checks. This gave a 4-5 times speedup.
Tested using a dictionary for coordinate to index translation, but performance was degraded.
Added new issue about rewriting code to use only indexes instead.